### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,12 @@
     "@types/jest": "^29.5.0",
     "jest": "^29.5.0",
     "jsdom": "^21.1.1",
+    "rollup-plugin-node-polyfills": "^0.2.1",
+    "rollup-plugin-polyfill-node": "^0.12.0",
     "ts-jest": "^29.1.0",
     "tsup": "^6.7.0",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "vite-plugin-dts": "^2.0.2"
   },
   "dependencies": {
     "@onsol/tldparser": "^0.5.3",
@@ -53,9 +56,6 @@
     "@solflare-wallet/pfp": "^0.1.0",
     "crypto-browserify": "^3.12.0",
     "dotenv": "^16.0.3",
-    "fetch-unfucked": "^1.0.0",
-    "rollup-plugin-node-polyfills": "^0.2.1",
-    "rollup-plugin-polyfill-node": "^0.12.0",
-    "vite-plugin-dts": "^2.0.2"
+    "fetch-unfucked": "^1.0.0"
   }
 }


### PR DESCRIPTION
Moved following deps to devDependencies:
```
rollup-plugin-node-polyfills
rollup-plugin-polyfill-node
vite-plugin-dts
```

I didn't test extensively!
Also notice that there is a major upgrade for vite-plugin-dts to 3.2.0 available

`vite-plugin-dts` causes security warnings for `npm audit`:
```
# npm audit report

semver  7.0.0 - 7.5.1
Severity: moderate
semver vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
No fix available
node_modules/@microsoft/api-extractor/node_modules/semver
node_modules/@rushstack/node-core-library/node_modules/semver
  @microsoft/api-extractor  7.9.1 - 7.36.2
  Depends on vulnerable versions of @microsoft/api-extractor-model
  Depends on vulnerable versions of @rushstack/node-core-library
  Depends on vulnerable versions of semver
  node_modules/@microsoft/api-extractor
    vite-plugin-dts  >=1.1.0
    Depends on vulnerable versions of @microsoft/api-extractor
    Depends on vulnerable versions of @rushstack/node-core-library
    node_modules/vite-plugin-dts
      @portal-payments/solana-wallet-names  *
      Depends on vulnerable versions of vite-plugin-dts
      node_modules/@portal-payments/solana-wallet-names
  @rushstack/node-core-library  >=3.25.0
  Depends on vulnerable versions of semver
  node_modules/@rushstack/node-core-library
    @microsoft/api-extractor-model  >=7.8.12
    Depends on vulnerable versions of @rushstack/node-core-library
    node_modules/@microsoft/api-extractor-model

6 moderate severity vulnerabilities
```